### PR TITLE
寵物法術傷害公式調整

### DIFF
--- a/Modules/ybNenSkill.lua
+++ b/Modules/ybNenSkill.lua
@@ -1,7 +1,7 @@
----æ¨¡å—ç±»
+---Ä£¿éÀà
 local YbNenSkill = ModuleBase:createModule('ybNenSkill')
 
---- åŠ è½½æ¨¡å—é’©å­
+--- ¼ÓÔØÄ£¿é¹³×Ó
 function YbNenSkill:onLoad()
   self:logInfo('load')
   self:regCallback('DamageCalculateEvent', Func.bind(self.OnDamageCalculateCallBack, self))
@@ -14,13 +14,13 @@ function YbNenSkill:OnDamageCalculateCallBack(charIndex, defCharIndex, oriDamage
          local leader1 = Battle.GetPlayer(battleIndex,0)
          local leader2 = Battle.GetPlayer(battleIndex,5)
          local leader = leader1
-         if Char.GetData(leader2, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_äºº then
+         if Char.GetData(leader2, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_ÈË then
                leader = leader2
          end
-         if  flg == CONST.DamageFlags.Normal and Char.GetData(defCharIndex, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_å®   then  ---å® ç‰©ä¸ºç‰©ç†å—æ”»æ–¹äº‹ä»¶ï¼Œè¢«åŠ¨æŠ€èƒ½åªèƒ½äºŒé€‰ä¸€
+         if  flg == CONST.DamageFlags.Normal and Char.GetData(defCharIndex, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_³è  then  ---³èÎïÎªÎïÀíÊÜ¹¥·½ÊÂ¼ş£¬±»¶¯¼¼ÄÜÖ»ÄÜ¶şÑ¡Ò»
            for i=0,9 do
                local skillId = Pet.GetSkill(defCharIndex, i)
-               if (skillId == 1319) then  --å® ç‰©è¢«åŠ¨ã€éš±å¿è‡ªé‡ã€‘
+               if (skillId == 1319) then  --³èÎï±»¶¯¡¾ë[ÈÌ×ÔÖØ¡¿
                  local battleturn= Battle.GetTurn(battleIndex);
                  local yrzz= 0.75 + (battleturn*0.05);
                  if battleturn>=10 then
@@ -28,13 +28,13 @@ function YbNenSkill:OnDamageCalculateCallBack(charIndex, defCharIndex, oriDamage
                  end
                  local damage = damage * yrzz;
                  print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        NLG.Say(leader,defCharIndex,"ã€éš±å¿è‡ªé‡ã€‘ï¼ï¼",4,3);
+                 if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                        NLG.Say(leader,defCharIndex,"¡¾ë[ÈÌ×ÔÖØ¡¿£¡£¡",4,3);
                  end
-                 --NLG.Say(-1,-1,"è¿›å…¥æˆ˜æ–—æ—¶é™ä½å—åˆ°çš„ç‰©ç†ä¼¤å®³25%ï¼Œæ­¤æ•ˆæœåœ¨æˆ˜æ–—ä¸­æ¯å›åˆå‡å°‘5%ï¼Œæœ€å¤šå‡å°‘è‡³50%",4,3);
+                 --NLG.Say(-1,-1,"½øÈëÕ½¶·Ê±½µµÍÊÜµ½µÄÎïÀíÉËº¦25%£¬´ËĞ§¹ûÔÚÕ½¶·ÖĞÃ¿»ØºÏ¼õÉÙ5%£¬×î¶à¼õÉÙÖÁ50%",4,3);
                  return damage;
                end
-               if (skillId == 1519) then  --å® ç‰©è¢«åŠ¨ã€å¨é£å‡›å‡›ã€‘
+               if (skillId == 1519) then  --³èÎï±»¶¯¡¾Íş·çÁİÁİ¡¿
                  local battleturn= Battle.GetTurn(battleIndex);
                  local wfll= 1 - (battleturn*0.03);
                  if battleturn>=10 then
@@ -42,17 +42,17 @@ function YbNenSkill:OnDamageCalculateCallBack(charIndex, defCharIndex, oriDamage
                  end
                  local damage = damage * wfll;
                  print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        NLG.Say(leader,defCharIndex,"ã€å¨é¢¨å‡œå‡œã€‘ï¼ï¼",4,3);
+                 if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                        NLG.Say(leader,defCharIndex,"¡¾ÍşïL„C„C¡¿£¡£¡",4,3);
                  end
-                 --NLG.Say(-1,-1,"è¿›å…¥æˆ˜æ–—æ—¶é™ä½å—åˆ°çš„é­”æ³•ä¼¤å®³0%ï¼Œæ­¤æ•ˆæœåœ¨æˆ˜æ–—ä¸­æ¯å›åˆæé«˜3%ï¼Œæœ€é«˜30%",4,3);
+                 --NLG.Say(-1,-1,"½øÈëÕ½¶·Ê±½µµÍÊÜµ½µÄÄ§·¨ÉËº¦0%£¬´ËĞ§¹ûÔÚÕ½¶·ÖĞÃ¿»ØºÏÌá¸ß3%£¬×î¸ß30%",4,3);
                  return damage;
                end
            end
-         elseif  flg == CONST.DamageFlags.Magic and Char.GetData(defCharIndex, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_å®   then  ---å® ç‰©ä¸ºé­”æ³•å—æ”»æ–¹äº‹ä»¶ï¼Œè¢«åŠ¨æŠ€èƒ½åªèƒ½äºŒé€‰ä¸€
+         elseif  flg == CONST.DamageFlags.Magic and Char.GetData(defCharIndex, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_³è  then  ---³èÎïÎªÄ§·¨ÊÜ¹¥·½ÊÂ¼ş£¬±»¶¯¼¼ÄÜÖ»ÄÜ¶şÑ¡Ò»
            for i=0,9 do
                local skillId = Pet.GetSkill(defCharIndex, i)
-               if (skillId == 1419) then  --å® ç‰©è¢«åŠ¨ã€è¬å¿µçš†ç©ºã€‘
+               if (skillId == 1419) then  --³èÎï±»¶¯¡¾ÈfÄî½Ô¿Õ¡¿
                  local battleturn= Battle.GetTurn(battleIndex);
                  local wnjk= 0.75 + (battleturn*0.05);
                  if battleturn>=10 then
@@ -60,13 +60,13 @@ function YbNenSkill:OnDamageCalculateCallBack(charIndex, defCharIndex, oriDamage
                  end
                  local damage = damage * wnjk;
                  print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        NLG.Say(leader,defCharIndex,"ã€è¬å¿µçš†ç©ºã€‘ï¼ï¼",4,3);
+                 if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                        NLG.Say(leader,defCharIndex,"¡¾ÈfÄî½Ô¿Õ¡¿£¡£¡",4,3);
                  end
-                 --NLG.Say(-1,-1,"è¿›å…¥æˆ˜æ–—æ—¶é™ä½å—åˆ°çš„é­”æ³•ä¼¤å®³25%ï¼Œæ­¤æ•ˆæœåœ¨æˆ˜æ–—ä¸­æ¯å›åˆå‡å°‘5%ï¼Œæœ€å¤šå‡å°‘è‡³50%",4,3);
+                 --NLG.Say(-1,-1,"½øÈëÕ½¶·Ê±½µµÍÊÜµ½µÄÄ§·¨ÉËº¦25%£¬´ËĞ§¹ûÔÚÕ½¶·ÖĞÃ¿»ØºÏ¼õÉÙ5%£¬×î¶à¼õÉÙÖÁ50%",4,3);
                  return damage;
                end
-               if (skillId == 1519) then  --å® ç‰©è¢«åŠ¨ã€å¨é£å‡›å‡›ã€‘
+               if (skillId == 1519) then  --³èÎï±»¶¯¡¾Íş·çÁİÁİ¡¿
                  local battleturn= Battle.GetTurn(battleIndex);
                  local wfll= 1 - (battleturn*0.03);
                  if battleturn>=10 then
@@ -74,17 +74,17 @@ function YbNenSkill:OnDamageCalculateCallBack(charIndex, defCharIndex, oriDamage
                  end
                  local damage = damage * wfll;
                  print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        NLG.Say(leader,defCharIndex,"ã€å¨é¢¨å‡œå‡œã€‘ï¼ï¼",4,3);
+                 if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                        NLG.Say(leader,defCharIndex,"¡¾ÍşïL„C„C¡¿£¡£¡",4,3);
                  end
-                 --NLG.Say(-1,-1,"è¿›å…¥æˆ˜æ–—æ—¶é™ä½å—åˆ°çš„ç‰©ç†ä¼¤å®³0%ï¼Œæ­¤æ•ˆæœåœ¨æˆ˜æ–—ä¸­æ¯å›åˆæé«˜3%ï¼Œæœ€é«˜30%",4,3);
+                 --NLG.Say(-1,-1,"½øÈëÕ½¶·Ê±½µµÍÊÜµ½µÄÎïÀíÉËº¦0%£¬´ËĞ§¹ûÔÚÕ½¶·ÖĞÃ¿»ØºÏÌá¸ß3%£¬×î¸ß30%",4,3);
                  return damage;
                end
            end
-         elseif  flg == CONST.DamageFlags.Normal and Char.GetData(charIndex, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_å®   then  ---å® ç‰©ä¸ºæ”»å‡»æ–¹äº‹ä»¶ï¼Œè¢«åŠ¨æŠ€èƒ½åªèƒ½äºŒé€‰ä¸€
+         elseif  flg == CONST.DamageFlags.Normal and Char.GetData(charIndex, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_³è  then  ---³èÎïÎª¹¥»÷·½ÊÂ¼ş£¬±»¶¯¼¼ÄÜÖ»ÄÜ¶şÑ¡Ò»
            for i=0,9 do
                local skillId = Pet.GetSkill(charIndex, i)
-               if (skillId == 1619) then  --å® ç‰©è¢«åŠ¨ã€å¤§èƒ†æ— ç•ã€‘
+               if (skillId == 1619) then  --³èÎï±»¶¯¡¾´óµ¨ÎŞÎ·¡¿
                  local battleturn= Battle.GetTurn(battleIndex);
                  local ddww= 1.3 - (battleturn*0.06);
                  if battleturn>=5 then
@@ -92,13 +92,13 @@ function YbNenSkill:OnDamageCalculateCallBack(charIndex, defCharIndex, oriDamage
                  end
                  local damage = damage * ddww;
                  print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        NLG.Say(leader,charIndex,"ã€å¤§è†½ç„¡ç•ã€‘ï¼ï¼",4,3);
+                 if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                        NLG.Say(leader,charIndex,"¡¾´óÄ‘ŸoÎ·¡¿£¡£¡",4,3);
                  end
-                 --NLG.Say(-1,-1,"è¿›å…¥æˆ˜æ–—æ—¶æé«˜é€ æˆçš„æ‰€æœ‰ä¼¤å®³30%ï¼Œæ­¤æ•ˆæœåœ¨æˆ˜æ–—ä¸­æ¯å›åˆé™ä½6%",4,3);
+                 --NLG.Say(-1,-1,"½øÈëÕ½¶·Ê±Ìá¸ßÔì³ÉµÄËùÓĞÉËº¦30%£¬´ËĞ§¹ûÔÚÕ½¶·ÖĞÃ¿»ØºÏ½µµÍ6%",4,3);
                  return damage;
                end
-               if (skillId == 1719) then  --å® ç‰©è¢«åŠ¨ã€ç™¾æˆ˜ç£¨ç»ƒã€‘
+               if (skillId == 1719) then  --³èÎï±»¶¯¡¾°ÙÕ½Ä¥Á·¡¿
                  local battleturn= Battle.GetTurn(battleIndex);
                  local bzml= 1 + (battleturn*0.06);
                  if battleturn>=5 then
@@ -106,82 +106,32 @@ function YbNenSkill:OnDamageCalculateCallBack(charIndex, defCharIndex, oriDamage
                  end
                  local damage = damage * bzml;
                  print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        NLG.Say(leader,charIndex,"ã€ç™¾æˆ°ç£¨ç·´ã€‘ï¼ï¼",4,3);
+                 if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                        NLG.Say(leader,charIndex,"¡¾°Ù‘ğÄ¥¾š¡¿£¡£¡",4,3);
                  end
-                 --NLG.Say(-1,-1,"è¿›å…¥æˆ˜æ–—æ—¶æé«˜é€ æˆçš„æ‰€æœ‰ä¼¤å®³0%ï¼Œæ­¤æ•ˆæœåœ¨æˆ˜æ–—ä¸­æ¯å›åˆä¸Šå‡6%ï¼Œæœ€é«˜30%",4,3);
+                 --NLG.Say(-1,-1,"½øÈëÕ½¶·Ê±Ìá¸ßÔì³ÉµÄËùÓĞÉËº¦0%£¬´ËĞ§¹ûÔÚÕ½¶·ÖĞÃ¿»ØºÏÉÏÉı6%£¬×î¸ß30%",4,3);
                  return damage;
                end
            end
-         elseif  flg == CONST.DamageFlags.Magic and Char.GetData(charIndex, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_å®   then
-               local LvRate = Char.GetData(charIndex,CONST.CHAR_ç­‰çº§);
-               local Spirit = Char.GetData(charIndex,CONST.CHAR_ç²¾ç¥);
+         elseif  flg == CONST.DamageFlags.Magic and Char.GetData(charIndex, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_³è  then
+               local LvRate = Char.GetData(charIndex,CONST.CHAR_µÈ¼¶);
+               local Spirit = Char.GetData(charIndex,CONST.CHAR_¾«Éñ);
                if LvRate <= 50  then
                         LvRate = 1;
                else
-                        LvRate = LvRate/10;
+                        LvRate = LvRate/50;
                end
                if Spirit <= 200  then
                         SpRate = 1;
                else
                         SpRate = Spirit/200;
                end
-               if (com3 >= 1930 and com3 <= 1939) or (com3 >= 2330 and com3 <= 2339) or (com3 >= 2750 and com3 <= 2759)  then    --éš•çŸ³é­”æ³•
-                 if com3 >= 1930 and com3 <= 1939  then
-                        damage = damage * SpRate + Spirit * 0.5 * LvRate ;
-                 elseif com3 >= 2330 and com3 <= 2339  then
-                        damage = damage * SpRate + Spirit * 0.25 * LvRate;
-                 elseif com3 >= 2750 and com3 <= 2759  then
-                        damage = damage * SpRate + Spirit * 0.125 * LvRate;
-                 end
-                 print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        --NLG.Say(leader,charIndex,"ã€é­”æ³•å°åŠ›ã€‘ï¼ï¼",4,3);
-                 end
-                 return damage;
-               end
-               if (com3 >= 2030 and com3 <= 2039) or (com3 >= 2430 and com3 <= 2439) or (com3 >= 2850 and com3 <= 2859)  then    --å†°å‡é­”æ³•
-                 if com3 >= 2030 and com3 <= 2039  then
-                        damage = damage * SpRate + Spirit * 0.5 * LvRate;
-                 elseif com3 >= 2430 and com3 <= 2439  then
-                        damage = damage * SpRate + Spirit * 0.25 * LvRate;
-                 elseif com3 >= 2850 and com3 <= 2859  then
-                        damage = damage * SpRate + Spirit * 0.125 * LvRate;
-                 end
-                 print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        --NLG.Say(leader,charIndex,"ã€é­”æ³•å°åŠ›ã€‘ï¼ï¼",4,3);
-                 end
-                 return damage;
-               end
-               if (com3 >= 2130 and com3 <= 2139) or (com3 >= 2530 and com3 <= 2539) or (com3 >= 2950 and com3 <= 2959)  then    --ç«ç„°é­”æ³•
-                 if com3 >= 2130 and com3 <= 2139  then
-                        damage = damage * SpRate + Spirit * 0.5 * LvRate;
-                 elseif com3 >= 2530 and com3 <= 2539  then
-                        damage = damage * SpRate + Spirit * 0.25 * LvRate;
-                 elseif com3 >= 2950 and com3 <= 2959  then
-                        damage = damage * SpRate + Spirit * 0.125 * LvRate;
-                 end
-                 print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        --NLG.Say(leader,charIndex,"ã€é­”æ³•å°åŠ›ã€‘ï¼ï¼",4,3);
-                 end
-                 return damage;
-               end
-               if (com3 >= 2230 and com3 <= 2239) or (com3 >= 2630 and com3 <= 2639) or (com3 >= 3050 and com3 <= 3059)  then    --é¢¨åˆƒé­”æ³•
-                 if com3 >= 2230 and com3 <= 2239  then
-                        damage = damage * SpRate + Spirit * 0.5 * LvRate;
-                 elseif com3 >= 2630 and com3 <= 2639  then
-                        damage = damage * SpRate + Spirit * 0.25 * LvRate;
-                 elseif com3 >= 3050 and com3 <= 3059  then
-                        damage = damage * SpRate + Spirit * 0.125 * LvRate;
-                 end
-                 print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        --NLG.Say(leader,charIndex,"ã€é­”æ³•å°åŠ›ã€‘ï¼ï¼",4,3);
-                 end
-                 return damage;
-               end
+               local damage = damage * SpRate + Spirit * 0.5 * LvRate ;
+               print(damage)
+               --if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                      --NLG.Say(leader,charIndex,"¡¾Ä§·¨Œ§Á¦¡¿£¡£¡",4,3);
+               --end
+              return damage;
 
          end
   return damage;
@@ -194,55 +144,55 @@ function YbNenSkill:OnTechOptionEventCallBack(charIndex, option, techID, val)
       local leader1 = Battle.GetPlayer(battleIndex,0)
       local leader2 = Battle.GetPlayer(battleIndex,5)
       local leader = leader1
-      if Char.GetData(leader2, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_äºº then
+      if Char.GetData(leader2, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_ÈË then
             leader = leader2
       end
-      if Char.GetData(charIndex, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_äºº then
-            local NEN = Char.GetData(charIndex,CONST.CHAR_ç§æ—);
+      if Char.GetData(charIndex, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_ÈË then
+            local NEN = Char.GetData(charIndex,CONST.CHAR_ÖÖ×å);
             local JL1 = NLG.Rand(1,4);
             --print(NEN)
             --print(JL1)
             if JL1 >= 1 then
                   local item5 = Char.GetItemIndex(charIndex, 5);
-                  local item5_Id = Item.GetData(item5, CONST.é“å…·_ID);
+                  local item5_Id = Item.GetData(item5, CONST.µÀ¾ß_ID);
                   local item6 = Char.GetItemIndex(charIndex, 6);
-                  local item6_Id = Item.GetData(item6, CONST.é“å…·_ID);
+                  local item6_Id = Item.GetData(item6, CONST.µÀ¾ß_ID);
                   if techID >= 400 and techID <= 409 and item6_Id == 900333  then
                         if option == 'DD:' then
-                              if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                                  NLG.Say(leader,charIndex,"ã€èšæ°£ã€‘ï¼ï¼",4,3);
+                              if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                                  NLG.Say(leader,charIndex,"¡¾¾Ûšâ¡¿£¡£¡",4,3);
                               end
-                              --NLG.Say(-1,-1,"ä½£å…µæŠ€èƒ½å¼ºåŒ–æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€æ°”åŠŸå¼¹å¨åŠ›å¢åŠ 30%ã€‘",4,3);
+                              --NLG.Say(-1,-1,"Ó¶±ø¼¼ÄÜÇ¿»¯Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾Æø¹¦µ¯ÍşÁ¦Ôö¼Ó30%¡¿",4,3);
                               return val+30;
                         end
                         return val
                   end
                   if techID >= 9500 and techID <= 9509 and item6_Id == 900333  then
                         if option == 'AM:' then
-                              if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                                  NLG.Say(leader,charIndex,"ã€é©Ÿé›¨ã€‘ï¼ï¼",4,3);
+                              if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                                  NLG.Say(leader,charIndex,"¡¾óEÓê¡¿£¡£¡",4,3);
                               end
-                              --NLG.Say(-1,-1,"ä½£å…µæŠ€èƒ½å¼ºåŒ–æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ä¹±å°„æ•°é‡å¢åŠ 3ã€‘",4,3);
+                              --NLG.Say(-1,-1,"Ó¶±ø¼¼ÄÜÇ¿»¯Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÂÒÉäÊıÁ¿Ôö¼Ó3¡¿",4,3);
                               return val+3;
                         end
                         return val
                   end
                   if techID >= 6600 and techID <= 6609 and item5_Id == 900330 then
                         if option == 'RR:' then
-                              if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                                  NLG.Say(leader,charIndex,"ã€è–é­‚ã€‘ï¼ï¼",4,3);
+                              if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                                  NLG.Say(leader,charIndex,"¡¾Â}»ê¡¿£¡£¡",4,3);
                               end
-                              --NLG.Say(-1,-1,"ä½£å…µæŠ€èƒ½å¼ºåŒ–æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€è¶…æ¢ç‰¹æ®Šå¢åŠ 100%ã€‘",4,3);
+                              --NLG.Say(-1,-1,"Ó¶±ø¼¼ÄÜÇ¿»¯Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾³¬»ÖÌØÊâÔö¼Ó100%¡¿",4,3);
                               return val+100;
                         end
                         return val
                   end
                   if techID >= 1260 and techID <= 1269 and item5_Id == 900330  then
                         if option == 'D2:' then
-                              if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                                  NLG.Say(leader,charIndex,"ã€éˆå…‰ã€‘ï¼ï¼",4,3);
+                              if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                                  NLG.Say(leader,charIndex,"¡¾ì`¹â¡¿£¡£¡",4,3);
                               end
-                              --NLG.Say(-1,-1,"ä½£å…µæŠ€èƒ½å¼ºåŒ–æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€æ˜å‡€ç‰¹æ®Šå¢åŠ 100%ã€‘",4,3);
+                              --NLG.Say(-1,-1,"Ó¶±ø¼¼ÄÜÇ¿»¯Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾Ã÷¾»ÌØÊâÔö¼Ó100%¡¿",4,3);
                               return val+100;
                         end
                         return val
@@ -251,7 +201,7 @@ function YbNenSkill:OnTechOptionEventCallBack(charIndex, option, techID, val)
       end
 end
 
---- å¸è½½æ¨¡å—é’©å­
+--- Ğ¶ÔØÄ£¿é¹³×Ó
 function YbNenSkill:onUnload()
   self:logInfo('unload')
 end


### PR DESCRIPTION
等級率=等級/50，未到等級50比率固定為1
精神率=精神/200，未到精神200比率固定為1
調整後傷害=原傷害 * 精神率 + 精神 * 0.5 * 等級率 ;
(不分單體、強力、超強魔法)