### PR TITLE
人物種族特性新增和修改

### DIFF
--- a/Modules/specialSkill.lua
+++ b/Modules/specialSkill.lua
@@ -1,15 +1,7 @@
----æ¨¡å—ç±»
+---Ä£¿éÀà
 local SpecialSkill = ModuleBase:createModule('specialSkill')
 
-Equipment ={}
-for eee = 0,799 do
-	Equipment[eee] = {}
-	Equipment[eee][0] = 0  --åˆå§‹åŒ–å›åˆæ•°
-	Equipment[eee][1] = 0  --åˆå§‹åŒ–æ‰“å‡»æ•°
-end
-
-
---- åŠ è½½æ¨¡å—é’©å­
+--- ¼ÓÔØÄ£¿é¹³×Ó
 function SpecialSkill:onLoad()
   self:logInfo('load')
   self:regCallback('DamageCalculateEvent', Func.bind(self.OnDamageCalculateCallBack, self))
@@ -23,44 +15,64 @@ function SpecialSkill:OnDamageCalculateCallBack(charIndex, defCharIndex, oriDama
          local leader2 = Battle.GetPlayer(battleIndex,5)
          local leader = leader1
          --print(charIndex)
-         if Char.GetData(leader2, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_äºº then
+         if Char.GetData(leader2, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_ÈË then
                leader = leader2
          end
-         if flg ~= CONST.DamageFlags.Miss and flg ~= CONST.DamageFlags.Dodge and flg ~= CONST.DamageFlags.Magic and Char.GetData(charIndex, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_äºº  then
-               local RaceType = Char.GetData(charIndex,CONST.CHAR_ç§æ—);
-               if ( RaceType == CONST.ç§æ—_äººå‹ ) then 
+         if flg ~= CONST.DamageFlags.Miss and flg ~= CONST.DamageFlags.Dodge and flg ~= CONST.DamageFlags.Magic and Char.GetData(charIndex, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_ÈË  then
+               local RaceType = Char.GetData(charIndex,CONST.CHAR_ÖÖ×å);
+               if ( RaceType == CONST.ÖÖ×å_ÈËĞÍ) then 
                  local battleturn = Battle.GetTurn(battleIndex);
-                 if (battleturn == 0) then
-                     Equipment[charIndex][0] = battleturn;
-                     Equipment[charIndex][1] = 0;
-                 elseif (battleturn > Equipment[charIndex][0]) then
-                     Equipment[charIndex][0] = battleturn;
-                     Equipment[charIndex][1] = 0;
-                 end
-                 Equipment[charIndex][1] = Equipment[charIndex][1] + 1;
-                 local cj= 1 + (Equipment[charIndex][1]*0.015);
-                 if Equipment[charIndex][1]>=3 then
+                 local lh = NLG.Rand(1,10);
+                 local cj= 1 + (lh*0.015);
+                 if lh>=8 then
                           Char.SetData(charIndex, CONST.CHAR_BattleDamageReflec, 1);
-                          if Equipment[charIndex][1]>=5 then
-                                   Char.SetData(defCharIndex, CONST.CHAR_BattleModDrunk, 3);
-                                   if Equipment[charIndex][1]>=20 then
-                                            cj = 1.3;
-                                   end
+                          if lh>=10 then
+                                   Char.SetData(defCharIndex, CONST.CHAR_BattleReverse, 2);
                           end
                  end
-                 local damage = damage * cj;
-                 print(damage)
-                 Equipment[charIndex][1] = turnhit;
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        NLG.Say(charIndex,charIndex,"ã€å¯¸å‹ã€‘ï¼ï¼",4,3);
+                 if Char.GetData(defCharIndex, CONST.CHAR_BattleReverse)>=1  then
+                          cj = 1.3;
                  end
-                 --NLG.Say(-1,-1,"äººå‹ç³»äººç‰©åœ¨æˆ˜æ–—ä¸­æ¯æ¬¡æ‰“å‡»ä¼¤å®³æå‡1.5%ï¼Œè¾¾æ¬¡æ•°å¾—åˆ°é¢å¤–æ•ˆæœï¼Œæ¯å›åˆé‡ç½®æ¬¡æ•°",4,3);
+                 local damage = damage * cj;
+                 --print(damage)
+                 print(cj)
+                 if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                        NLG.Say(charIndex,charIndex,"¡¾´ç„Å¡¿£¡£¡",4,3);
+                 end
+                 --NLG.Say(-1,-1,"ÈËĞÍÏµÈËÎïÃ¿´ÎÉËº¦Ëæ»úÌáÉı1.5%~15%£¬ÓĞ30%µÄ¼¸ÂÊ×ÔÉí¹¥·´×´Ì¬1»ØºÏ£¬10%µÄ¼¸ÂÊÊ¹Ä¿±êÊô·´2»ØºÏ£¬¶ÔÒÑÊô·´Ä¿±êÉËº¦Ìá¸ß30%",4,3);
                  return damage;
                end
-               if ( RaceType == CONST.ç§æ—_é£è¡Œ ) then 
+               if ( RaceType == CONST.ÖÖ×å_Áú) then 
                  local battleturn = Battle.GetTurn(battleIndex);
-                 local defHpE = Char.GetData(defCharIndex,CONST.CHAR_è¡€);
-                 local defHpEM = Char.GetData(defCharIndex,CONST.CHAR_æœ€å¤§è¡€);
+                 local defHp = Char.GetData(charIndex,CONST.CHAR_Ñª);
+                 local defMpE = Char.GetData(defCharIndex,CONST.CHAR_Ä§);
+                 local defMpEM = Char.GetData(defCharIndex,CONST.CHAR_×î´óÄ§);
+                 local MpE08 = defMpE/defMpEM;
+                 if MpE08>=0.5  then
+                        wy = 1;
+                 else
+                        wy = 1.2;
+                 end
+                 if Char.GetData(defCharIndex, CONST.CHAR_BattleModDrunk)>=1  then
+                        damage = damage * wy + defHp * 0.5;
+                        if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                               NLG.Say(charIndex,charIndex,"¡¾Íş‰º¡¿£¡£¡",4,3);
+                        end
+                 else
+                        damage = damage * wy;
+                        Char.SetData(defCharIndex, CONST.CHAR_BattleModDrunk, 1);
+                        if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                               NLG.Say(charIndex,charIndex,"¡¾ıˆÏ¢¡¿£¡£¡",4,3);
+                        end
+                 end
+                 --print(damage)
+                 --NLG.Say(-1,-1,"ÁúÏµÈËÎïÃ¿´ÎÔì³ÉÉËº¦Ê±£¬¶Ô·Ç¾Æ×íµÄÄ¿±ê¾Æ×í1»ØºÏ£¬Ä§·¨ÖµÉÙÓÚ50%µÄÄ¿±êÉËº¦Ìá¸ß20%£¬¶ÔÒÑ¾Æ×íÄ¿±ê¶îÍâÊÜµ½ÎÒ·½ÑªÁ¿Öµ50%µÄ¿Ö¾åÉËº¦",4,3);
+                 return damage;
+               end
+               if ( RaceType == CONST.ÖÖ×å_·ÉĞĞ ) then 
+                 local battleturn = Battle.GetTurn(battleIndex);
+                 local defHpE = Char.GetData(defCharIndex,CONST.CHAR_Ñª);
+                 local defHpEM = Char.GetData(defCharIndex,CONST.CHAR_×î´óÑª);
                  local HpE05 = defHpE/defHpEM;
                  if HpE05<=0.5  then
                         yy = 1.2;
@@ -70,19 +82,19 @@ function SpecialSkill:OnDamageCalculateCallBack(charIndex, defCharIndex, oriDama
                  if NLG.Rand(1,10)>=8  then
                         damage = damage * yy;
                         Char.SetData(defCharIndex, CONST.CHAR_BattleModStone, 2);
-                        if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                               NLG.Say(charIndex,charIndex,"ã€ç¾½ç¿¼ã€‘ï¼ï¼",4,3);
+                        if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                               NLG.Say(charIndex,charIndex,"¡¾ÓğÒí¡¿£¡£¡",4,3);
                         end
                  else
                         damage = damage;
                  end
-                 print(damage)
-                 --NLG.Say(-1,-1,"é£è¡Œç³»äººç‰©æ¯æ¬¡é€ æˆä¼¤å®³æ—¶ï¼Œæœ‰30%çš„å‡ ç‡ä½¿ç›®æ ‡çŸ³åŒ–2å›åˆï¼Œå¯¹å½“å‰ç”Ÿå‘½å€¼å°‘äº50%çš„ç›®æ ‡ä¼¤å®³æé«˜20%",4,3);
+                 --print(damage)
+                 --NLG.Say(-1,-1,"·ÉĞĞÏµÈËÎïÃ¿´ÎÔì³ÉÉËº¦Ê±£¬ÓĞ30%µÄ¼¸ÂÊÊ¹Ä¿±êÊ¯»¯2»ØºÏ£¬¶Ôµ±Ç°ÉúÃüÖµÉÙÓÚ50%µÄÄ¿±êÉËº¦Ìá¸ß20%",4,3);
                  return damage;
                end
-               if ( RaceType == CONST.ç§æ—_æ˜†è™« ) then 
+               if ( RaceType == CONST.ÖÖ×å_À¥³æ ) then 
                  local battleturn = Battle.GetTurn(battleIndex);
-                 local defHpE = Char.GetData(defCharIndex,CONST.CHAR_è¡€);
+                 local defHpE = Char.GetData(defCharIndex,CONST.CHAR_Ñª);
                  local dy = defHpE*0.5;
                  if dy>=damage  then
                         dy = damage;
@@ -90,72 +102,72 @@ function SpecialSkill:OnDamageCalculateCallBack(charIndex, defCharIndex, oriDama
                  if NLG.Rand(1,10)>=8  then
                         damage = damage + dy;
                         Char.SetData(defCharIndex, CONST.CHAR_BattleModPoison, 3);
-                        if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                               NLG.Say(charIndex,charIndex,"ã€æ¯’æ¶²ã€‘ï¼ï¼",4,3);
+                        if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                               NLG.Say(charIndex,charIndex,"¡¾¶¾Òº¡¿£¡£¡",4,3);
                         end
                  else
                         damage = damage;
                  end
-                 print(damage)
-                 --NLG.Say(-1,-1,"æ˜†è™«ç³»äººç‰©æ¯æ¬¡é€ æˆä¼¤å®³æ—¶ï¼Œæœ‰30%çš„å‡ ç‡å¯¹ç›®æ ‡é€ æˆé¢å¤–çš„ç­‰åŒäºç›®æ ‡å½“å‰ç”Ÿå‘½å€¼ä¸€åŠçš„ä¼¤å®³å¹¶ä¸­æ¯’3å›åˆ",4,3);
+                 --print(damage)
+                 --NLG.Say(-1,-1,"À¥³æÏµÈËÎïÃ¿´ÎÔì³ÉÉËº¦Ê±£¬ÓĞ30%µÄ¼¸ÂÊ¶ÔÄ¿±êÔì³É¶îÍâµÄµÈÍ¬ÓÚÄ¿±êµ±Ç°ÉúÃüÖµÒ»°ëµÄÉËº¦²¢ÖĞ¶¾3»ØºÏ",4,3);
                  return damage;
                end
-               if ( RaceType == CONST.ç§æ—_é‡å…½ ) then 
+               if ( RaceType == CONST.ÖÖ×å_Ò°ÊŞ ) then 
                  local battleturn = Battle.GetTurn(battleIndex);
-                 local defHp = Char.GetData(charIndex,CONST.CHAR_è¡€);
-                 local defHpM = Char.GetData(charIndex,CONST.CHAR_æœ€å¤§è¡€);
+                 local defHp = Char.GetData(charIndex,CONST.CHAR_Ñª);
+                 local defHpM = Char.GetData(charIndex,CONST.CHAR_×î´óÑª);
                  local Hp02 = defHp/defHpM;
                  if Hp02<=0.2  then
                         Char.SetData(charIndex, CONST.CHAR_BattleDamageAbsrob, 2);
                  end
-                 local defHpEM = Char.GetData(defCharIndex,CONST.CHAR_æœ€å¤§è¡€);
+                 local defHpEM = Char.GetData(defCharIndex,CONST.CHAR_×î´óÑª);
                  local damage = damage + (defHpEM*0.1);
                  if NLG.Rand(1,10)>=8  then
                         Char.SetData(defCharIndex, CONST.CHAR_BattleModSleep, 1);
                  end
-                 print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        NLG.Say(charIndex,charIndex,"ã€æ’•è£‚ã€‘ï¼ï¼",4,3);
+                 --print(damage)
+                 if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                        NLG.Say(charIndex,charIndex,"¡¾ËºÁÑ¡¿£¡£¡",4,3);
                  end
-                 --NLG.Say(-1,-1,"é‡å…½ç³»äººç‰©å½“æœ€å¤§è¡€é‡ä½äº20%ï¼Œè‡ªèº«æ”»å¸çŠ¶æ€2å›åˆã€‚æ¯æ¬¡é€ æˆä¼¤å®³æ—¶ä½¿ç›®æ ‡å—åˆ°æœ€å¤§ç”Ÿå‘½å€¼10%çš„å‡ºè¡€ä¼¤å®³ï¼Œ30%çš„å‡ ç‡æ˜ç¡1å›åˆ",4,3);
+                 --NLG.Say(-1,-1,"Ò°ÊŞÏµÈËÎïµ±×î´óÑªÁ¿µÍÓÚ20%£¬×ÔÉí¹¥Îü×´Ì¬2»ØºÏ¡£Ã¿´ÎÔì³ÉÉËº¦Ê±Ê¹Ä¿±êÊÜµ½×î´óÉúÃüÖµ10%µÄ³öÑªÉËº¦£¬30%µÄ¼¸ÂÊ»èË¯1»ØºÏ",4,3);
                  return damage;
                end
-               if ( RaceType == CONST.ç§æ—_ç‰¹æ®Š ) then 
+               if ( RaceType == CONST.ÖÖ×å_ÌØÊâ ) then 
                  local battleturn = Battle.GetTurn(battleIndex);
-                 local defHp = Char.GetData(charIndex,CONST.CHAR_è¡€);
-                 local defHpM = Char.GetData(charIndex,CONST.CHAR_æœ€å¤§è¡€);
+                 local defHp = Char.GetData(charIndex,CONST.CHAR_Ñª);
+                 local defHpM = Char.GetData(charIndex,CONST.CHAR_×î´óÑª);
                  local Hp05 = defHp/defHpM;
                  if Hp05<=0.5  then
                         fc = 1+(1-Hp05);
                         damage = damage * fc;
                         Char.SetData(charIndex, CONST.CHAR_BattleDamageVanish, 1);
-                        if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                               NLG.Say(charIndex,charIndex,"ã€å¾©ä»‡ã€‘ï¼ï¼",4,3);
+                        if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                               NLG.Say(charIndex,charIndex,"¡¾Í³ğ¡¿£¡£¡",4,3);
                         end
                  else
                         damage = damage;
                         Char.SetData(charIndex, CONST.CHAR_BattleLpRecovery, 2);
-                        if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                               NLG.Say(charIndex,charIndex,"ã€è‡ªç™’ã€‘ï¼ï¼",4,3);
+                        if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                               NLG.Say(charIndex,charIndex,"¡¾×Ô°K¡¿£¡£¡",4,3);
                         end
                  end
-                 print(damage)
-                 --NLG.Say(-1,-1,"ç‰¹æ®Šç³»äººç‰©å½“æœ€å¤§è¡€é‡é«˜äº50%ï¼Œè‡ªèº«æ¢å¤çŠ¶æ€2å›åˆã€‚å½“æœ€å¤§è¡€é‡ä½äº50%ï¼Œè‡ªèº«æ”»æ— çŠ¶æ€1å›åˆï¼Œå¯¹ç›®æ ‡é€ æˆæŸå¤±è¡€é‡%çš„å¤ä»‡ä¼¤å®³",4,3);
+                 --print(damage)
+                 --NLG.Say(-1,-1,"ÌØÊâÏµÈËÎïµ±×î´óÑªÁ¿¸ßÓÚ50%£¬×ÔÉí»Ö¸´×´Ì¬2»ØºÏ¡£µ±×î´óÑªÁ¿µÍÓÚ50%£¬×ÔÉí¹¥ÎŞ×´Ì¬1»ØºÏ£¬¶ÔÄ¿±êÔì³ÉËğÊ§ÑªÁ¿%µÄ¸´³ğÉËº¦",4,3);
                  return damage;
                end
-               if ( RaceType == CONST.ç§æ—_é‡‘å± ) then 
+               if ( RaceType == CONST.ÖÖ×å_½ğÊô ) then 
                  local battleturn = Battle.GetTurn(battleIndex);
-                 local defHpM = Char.GetData(charIndex,CONST.CHAR_æœ€å¤§è¡€);
+                 local defHpM = Char.GetData(charIndex,CONST.CHAR_×î´óÑª);
                  local zb = defHpM*0.045;
                  local damage = damage + zb;
                  if NLG.Rand(1,10)>=6  then
                         Char.SetData(defCharIndex, CONST.CHAR_BattleModConfusion, 3);
                  end
-                 print(damage)
-                 if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                        NLG.Say(charIndex,charIndex,"ã€éšœå£ã€‘ï¼ï¼",4,3);
+                 --print(damage)
+                 if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                        NLG.Say(charIndex,charIndex,"¡¾ÕÏ±Ú¡¿£¡£¡",4,3);
                  end
-                 --NLG.Say(-1,-1,"é‡‘å±ç³»äººç‰©é€ æˆä¼¤å®³æ—¶ï¼Œé¢å¤–å¯¹ç›®æ ‡é€ æˆç›¸å½“äºæœ€å¤§è¡€é‡4.5%çš„ä¼¤å®³ï¼Œ50%çš„å‡ ç‡æ··ä¹±3å›åˆ",4,3);
+                 --NLG.Say(-1,-1,"½ğÊôÏµÈËÎïÔì³ÉÉËº¦Ê±£¬¶îÍâ¶ÔÄ¿±êÔì³ÉÏàµ±ÓÚ×î´óÑªÁ¿4.5%µÄÉËº¦£¬50%µÄ¼¸ÂÊ»ìÂÒ3»ØºÏ",4,3);
                  return damage;
                end
          else
@@ -170,263 +182,263 @@ function SpecialSkill:OnTechOptionEventCallBack(charIndex, option, techID, val)
       local leader1 = Battle.GetPlayer(battleIndex,0)
       local leader2 = Battle.GetPlayer(battleIndex,5)
       local leader = leader1
-      if Char.GetData(leader2, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_äºº then
+      if Char.GetData(leader2, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_ÈË then
             leader = leader2
       end
-      if Char.GetData(charIndex, CONST.CHAR_ç±»å‹) == CONST.å¯¹è±¡ç±»å‹_äºº then
-            local NEN = Char.GetData(charIndex,CONST.CHAR_ç§æ—);
+      if Char.GetData(charIndex, CONST.CHAR_ÀàĞÍ) == CONST.¶ÔÏóÀàĞÍ_ÈË then
+            local NEN = Char.GetData(charIndex,CONST.CHAR_ÖÖ×å);
             local JL1 = NLG.Rand(1,4);
             --print(NEN)
             --print(JL1)
             if JL1 >= 1 then
                   local item2 = Char.GetItemIndex(charIndex, 2);
-                  local item2_Id = Item.GetData(item2, CONST.é“å…·_ID);
+                  local item2_Id = Item.GetData(item2, CONST.µÀ¾ß_ID);
                   local item3 = Char.GetItemIndex(charIndex, 3);
-                  local item3_Id = Item.GetData(item3, CONST.é“å…·_ID);
-                  if techID >= 2730 and techID <= 2739 and NEN == CONST.ç§æ—_é‡å…½  then
+                  local item3_Id = Item.GetData(item3, CONST.µÀ¾ß_ID);
+                  if techID >= 2730 and techID <= 2739 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              if Char.GetData(leader,%å¯¹è±¡_é˜ŸèŠå¼€å…³%) == 1  then
-                                  NLG.Say(leader,charIndex,"ã€å¼ºå‡»ã€‘ï¼ï¼",4,3);
+                              if Char.GetData(leader,%¶ÔÏó_¶ÓÁÄ¿ª¹Ø%) == 1  then
+                                  NLG.Say(leader,charIndex,"¡¾Ç¿»÷¡¿£¡£¡",4,3);
                               end
-                              --NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€é™¨çŸ³å¼ºå‡»å¨åŠ›å¢åŠ 30%ã€‘");
+                              --NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÔÉÊ¯Ç¿»÷ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 2730 and techID <= 2739 and NEN == CONST.ç§æ—_é£è¡Œ  then
+                  if techID >= 2730 and techID <= 2739 and NEN == CONST.ÖÖ×å_·ÉĞĞ  then
                         if option == 'AM:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€é™¨çŸ³å¼ºå‡»æ•°é‡å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÔÉÊ¯Ç¿»÷ÊıÁ¿Ôö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID >= 2830 and techID <= 2839 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 2830 and techID <= 2839 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€å†°å†»å¼ºå‡»å¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾±ù¶³Ç¿»÷ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 2830 and techID <= 2839 and NEN == CONST.ç§æ—_é£è¡Œ  then
+                  if techID >= 2830 and techID <= 2839 and NEN == CONST.ÖÖ×å_·ÉĞĞ  then
                         if option == 'AM:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€å†°å†»å¼ºå‡»æ•°é‡å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾±ù¶³Ç¿»÷ÊıÁ¿Ôö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID >= 2930 and techID <= 2939 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 2930 and techID <= 2939 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç«ç„°å¼ºå‡»å¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾»ğÑæÇ¿»÷ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 2930 and techID <= 2939 and NEN == CONST.ç§æ—_é£è¡Œ  then
+                  if techID >= 2930 and techID <= 2939 and NEN == CONST.ÖÖ×å_·ÉĞĞ  then
                         if option == 'AM:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç«ç„°å¼ºå‡»æ•°é‡å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾»ğÑæÇ¿»÷ÊıÁ¿Ôö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID >= 3030 and techID <= 3039 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 3030 and techID <= 3039 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€é£åˆƒå¼ºå‡»å¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾·çÈĞÇ¿»÷ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 3030 and techID <= 3039 and NEN == CONST.ç§æ—_é£è¡Œ  then
+                  if techID >= 3030 and techID <= 3039 and NEN == CONST.ÖÖ×å_·ÉĞĞ  then
                         if option == 'AM:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€é£åˆƒå¼ºå‡»æ•°é‡å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾·çÈĞÇ¿»÷ÊıÁ¿Ôö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID >= 25710 and techID <= 25719 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 25710 and techID <= 25719 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€è‹¦æ— ä¹±èˆå¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾¿àÎŞÂÒÎèÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 25710 and techID <= 25719 and NEN == CONST.ç§æ—_é£è¡Œ  then
+                  if techID >= 25710 and techID <= 25719 and NEN == CONST.ÖÖ×å_·ÉĞĞ  then
                         if option == 'AM:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€è‹¦æ— ä¹±èˆæ•°é‡å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾¿àÎŞÂÒÎèÊıÁ¿Ôö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID >= 110 and techID <= 119 and NEN == CONST.ç§æ—_é¾™  then
+                  if techID >= 110 and techID <= 119 and NEN == CONST.ÖÖ×å_Áú  then
                         if option == 'TR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€å¿åˆ€ä¹±èˆå¨åŠ›å¢åŠ 10%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÈÌµ¶ÂÒÎèÍşÁ¦Ôö¼Ó10%¡¿");
                               return val+10;
                         end
                         return val
                   end
-                  if techID >= 26010 and techID <= 26019 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 26010 and techID <= 26019 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€å†²å‡»æ³¢åŠ¨å¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾³å»÷²¨¶¯ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 26010 and techID <= 26019 and NEN == CONST.ç§æ—_æ˜†è™«  then
+                  if techID >= 26010 and techID <= 26019 and NEN == CONST.ÖÖ×å_À¥³æ  then
                         if option == 'SR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€å†²å‡»æ³¢åŠ¨å€ç‡å¢åŠ 50%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾³å»÷²¨¶¯±¶ÂÊÔö¼Ó50%¡¿");
                               return val+50;
                         end
                         return val
                   end
-                  if techID >= 10505 and techID <= 10509 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 10505 and techID <= 10509 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç‹™æ€ç„å‡†å¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾¾ÑÉ±Ãé×¼ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 10505 and techID <= 10509 and NEN == CONST.ç§æ—_é£è¡Œ  then
+                  if techID >= 10505 and techID <= 10509 and NEN == CONST.ÖÖ×å_·ÉĞĞ  then
                         if option == 'AM:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç‹™æ€ç„å‡†æ•°é‡å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾¾ÑÉ±Ãé×¼ÊıÁ¿Ôö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID >= 515 and techID <= 519 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 515 and techID <= 519 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç‚¸è£‚çŒ›æ”»å¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾Õ¨ÁÑÃÍ¹¥ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 25815 and techID <= 25819 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 25815 and techID <= 25819 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€é”åˆ©å°„å‡»å¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÈñÀûÉä»÷ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 5019 and techID <= 5319 and NEN == CONST.ç§æ—_ç‰¹æ®Š  then
+                  if techID >= 5019 and techID <= 5319 and NEN == CONST.ÖÖ×å_ÌØÊâ  then
                         if option == 'AR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€é™·é˜±ç‰¹æ®Šå¢åŠ 200%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÏİÚåÌØÊâÔö¼Ó200%¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID >= 200510 and techID <= 200518 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 200510 and techID <= 200518 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€é“æ²™æŒå¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÌúÉ³ÕÆÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 200510 and techID <= 200518 and NEN == CONST.ç§æ—_é£è¡Œ  then
+                  if techID >= 200510 and techID <= 200518 and NEN == CONST.ÖÖ×å_·ÉĞĞ  then
                         if option == 'AM:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€é“æ²™æŒæ•°é‡å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÌúÉ³ÕÆÊıÁ¿Ôö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID == 529 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID == 529 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€é˜¿ä¿®ç½—éœ¸å‡°æ‹³å¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾°¢ĞŞÂŞ°Ô»ËÈ­ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 25880 and techID <= 25885 and NEN == CONST.ç§æ—_é£è¡Œ  then
+                  if techID >= 25880 and techID <= 25885 and NEN == CONST.ÖÖ×å_·ÉĞĞ  then
                         if option == 'AM:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€å…­åˆæ‹³æ•°é‡å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÁùºÏÈ­ÊıÁ¿Ôö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID >= 11105 and techID <= 11109 and NEN == CONST.ç§æ—_é¾™  then
+                  if techID >= 11105 and techID <= 11109 and NEN == CONST.ÖÖ×å_Áú  then
                         if option == 'TR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€å›æ—‹åˆ€åˆƒå¨åŠ›å¢åŠ 10%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾»ØĞıµ¶ÈĞÍşÁ¦Ôö¼Ó10%¡¿");
                               return val+10;
                         end
                         return val
                   end
-                  if techID >= 200705 and techID <= 200709 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 200705 and techID <= 200709 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€åå°„ä¼¤å®³å¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾·´ÉäÉËº¦ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID >= 8105 and techID <= 8109 and NEN == CONST.ç§æ—_é‡å…½  then
+                  if techID >= 8105 and techID <= 8109 and NEN == CONST.ÖÖ×å_Ò°ÊŞ  then
                         if option == 'DD:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€èˆå‘½æ”»å‡»å¨åŠ›å¢åŠ 30%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÉáÃü¹¥»÷ÍşÁ¦Ôö¼Ó30%¡¿");
                               return val+30;
                         end
                         return val
                   end
-                  if techID == 5919 and NEN == CONST.ç§æ—_é‡‘å±  then
+                  if techID == 5919 and NEN == CONST.ÖÖ×å_½ğÊô  then
                         if option == 'CH:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€å¤©ä½¿ä¹‹å‡»æŒç»­å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÌìÊ¹Ö®»÷³ÖĞøÔö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID == 6019 and NEN == CONST.ç§æ—_é‡‘å±  then
+                  if techID == 6019 and NEN == CONST.ÖÖ×å_½ğÊô  then
                         if option == 'CH:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€å¤©ä½¿ä¹‹æŠ¤æŒç»­å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÌìÊ¹Ö®»¤³ÖĞøÔö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID == 6619 and NEN == CONST.ç§æ—_é‡‘å±  then
+                  if techID == 6619 and NEN == CONST.ÖÖ×å_½ğÊô  then
                         if option == 'CH:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç¥åœ£é™ä¸´æŒç»­å¢åŠ 2ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÉñÊ¥½µÁÙ³ÖĞøÔö¼Ó2¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID == 6219 and NEN == CONST.ç§æ—_ç‰¹æ®Š  then
+                  if techID == 6219 and NEN == CONST.ÖÖ×å_ÌØÊâ  then
                         if option == 'AR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç¥åœ£ç¥ˆç¥·ç‰¹æ®Šå¢åŠ 200%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÉñÊ¥Æíµ»ÌØÊâÔö¼Ó200%¡¿");
                               return val+200;
                         end
                         return val
                   end
-                  if techID == 6329 and NEN == CONST.ç§æ—_ç‰¹æ®Š  then
+                  if techID == 6329 and NEN == CONST.ÖÖ×å_ÌØÊâ  then
                         if option == 'AR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç¥åœ£ç¥ˆç¥·ç‰¹æ®Šå¢åŠ 200%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÉñÊ¥Æíµ»ÌØÊâÔö¼Ó200%¡¿");
                               return val+200;
                         end
                         return val
                   end
-                  if techID >= 10628 and techID <= 10629 and NEN == CONST.ç§æ—_é¾™  then
+                  if techID >= 10628 and techID <= 10629 and NEN == CONST.ÖÖ×å_Áú  then
                               if option == 'TR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç¬èº«ä¹‹æœ¯å¨åŠ›å¢åŠ 10%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾Ë²ÉíÖ®ÊõÍşÁ¦Ôö¼Ó10%¡¿");
                               return val+10;
                         end
                         return val
                   end
-                  if techID == 200607 and NEN == CONST.ç§æ—_ç‰¹æ®Š  then
+                  if techID == 200607 and NEN == CONST.ÖÖ×å_ÌØÊâ  then
                         if option == 'AR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€é›·éï¼åƒé¸Ÿæµç‰¹æ®Šå¢åŠ 200%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾À×¶İ£®Ç§ÄñÁ÷ÌØÊâÔö¼Ó200%¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID == 201408 and NEN == CONST.ç§æ—_ç‰¹æ®Š  then
+                  if techID == 201408 and NEN == CONST.ÖÖ×å_ÌØÊâ  then
                         if option == 'AR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç«éï¼ç°ç§¯çƒ§ç‰¹æ®Šå¢åŠ 200%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾»ğ¶İ£®»Ò»ıÉÕÌØÊâÔö¼Ó200%¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID == 201209 and NEN == CONST.ç§æ—_ç‰¹æ®Š  then
+                  if techID == 201209 and NEN == CONST.ÖÖ×å_ÌØÊâ  then
                         if option == 'AR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€åœŸéï¼åœŸæµæ³¢ç‰¹æ®Šå¢åŠ 200%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾ÍÁ¶İ£®ÍÁÁ÷²¨ÌØÊâÔö¼Ó200%¡¿");
                               return val+2;
                         end
                         return val
                   end
-                  if techID == 201919 and NEN == CONST.ç§æ—_ç‰¹æ®Š  then
+                  if techID == 201919 and NEN == CONST.ÖÖ×å_ÌØÊâ  then
                         if option == 'AR:' then
-                              NLG.SystemMessage(charIndex,"ä¸“å±å¿µèƒ½åŠ›æ•ˆæœåŠ æˆå·²å‘åŠ¨ï¼ã€ç§½åœŸè½¬ç”Ÿç‰¹æ®Šå¢åŠ 200%ã€‘");
+                              NLG.SystemMessage(charIndex,"×¨ÊôÄîÄÜÁ¦Ğ§¹û¼Ó³ÉÒÑ·¢¶¯£¡¡¾»àÍÁ×ªÉúÌØÊâÔö¼Ó200%¡¿");
                               return val+200;
                         end
                         return val
@@ -435,103 +447,7 @@ function SpecialSkill:OnTechOptionEventCallBack(charIndex, option, techID, val)
       end
 end
 
-function pequipitemZS(index,itemid)  ---å·¦æ‰‹
-      
- for k=2,2 do
-     local itemindex = Char.GetItemIndex(index,k);
-     if(itemid == Item.GetData(itemindex, %é“å…·_ID%))then
-        return true;
-     end
- end
- return false;
-
-end
-
-function pequipitemYS(index,itemid)  --å³æ‰‹
-      
- for k=3,3 do
-     local itemindex = Char.GetItemIndex(index,k);
-     if(itemid == Item.GetData(itemindex, %é“å…·_ID%))then
-        return true;
-     end
- end
- return false;
-
-end
-
-function pequipitemT(index,itemid)  ---å¤´éƒ¨
-      
- for k=0,0 do
-     local itemindex = Char.GetItemIndex(index,k);
-     if(itemid == Item.GetData(itemindex, %é“å…·_ID%))then
-        return true;
-     end
- end
- return false;
-
-end
-
-function pequipitemS(index,itemid)  ---èº«
-      
- for k=1,1 do
-     local itemindex = Char.GetItemIndex(index,k);
-     if(itemid == Item.GetData(itemindex, %é“å…·_ID%))then
-        return true;
-     end
- end
- return false;
-
-end
-
-function pequipitemX(index,itemid)  ---é‹
-      
- for k=4,4 do
-     local itemindex = Char.GetItemIndex(index,k);
-     if(itemid == Item.GetData(itemindex, %é“å…·_ID%))then
-        return true;
-     end
- end
- return false;
-
-end
-
-function pequipitemSS1(index,itemid) --é¥°å“1
-      
- for k=5,5 do
-     local itemindex = Char.GetItemIndex(index,k);
-     if(itemid == Item.GetData(itemindex, %é“å…·_ID%))then
-        return true;
-     end
- end
- return false;
-
-end
-
-function pequipitemSS2(index,itemid) --é¥°å“2
-      
- for k=6,6 do
-     local itemindex = Char.GetItemIndex(index,k);
-     if(itemid == Item.GetData(itemindex, %é“å…·_ID%))then
-        return true;
-     end
- end
- return false;
-
-end
-
-function pequipitemSJ(index,itemid) --æ°´æ™¶
-      
- for k=7,7 do
-     local itemindex = Char.GetItemIndex(index,k);
-     if(itemid == Item.GetData(itemindex, %é“å…·_ID%))then
-        return true;
-     end
- end
- return false;
-
-end
-
---- å¸è½½æ¨¡å—é’©å­
+--- Ğ¶ÔØÄ£¿é¹³×Ó
 function SpecialSkill:onUnload()
   self:logInfo('unload')
 end


### PR DESCRIPTION
人型系種族特性修改：人型系人物每次傷害隨機提升1.5%~15%，有30%的幾率自身攻反狀態1回合，10%的幾率使目標屬反2回合，對已屬反目標傷害提高30%。

新增龍系種族特性：龍系人物每次造成傷害時，對非酒醉的目標酒醉1回合，魔法值少於50%的目標傷害提高20%，對已酒醉目標額外受到我方血量值50%的恐懼傷害。